### PR TITLE
Deletion of upower information

### DIFF
--- a/plugins/powerd/README.md
+++ b/plugins/powerd/README.md
@@ -1,10 +1,11 @@
-UPower Support
+Powerd Support
 ==============
 
 Introduction
 ------------
 
-This plugin is used to ensure that some updates are not done on battery power.
+This plugin is used to ensure that some updates are not done on battery power
+and that there is sufficient battery power for certain updates that are.
 
 Vendor ID Security
 ------------------
@@ -13,4 +14,4 @@ This protocol does not create a device and thus requires no vendor ID set.
 
 External interface access
 -------------------------
-This plugin requires access to the dbus interface `org.freedesktop.UPower`.
+This plugin requires access to a dbus interface that is to be discussed.

--- a/plugins/powerd/fu-plugin-cros-powerd.c
+++ b/plugins/powerd/fu-plugin-cros-powerd.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <fwupdplugin.h>
+
+#define MINIMUM_BATTERY_PERCENTAGE_FALLBACK	10
+
+struct FuPluginData {
+	GDBusProxy		*proxy;		/* nullable */
+};
+
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	//fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+	//fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
+        
+        return;
+}
+
+void
+fu_plugin_destroy (FuPlugin *plugin)
+{
+	FuPluginData *data = fu_plugin_get_data (plugin);
+	if (data->proxy != NULL)
+		g_object_unref (data->proxy);
+}
+
+static void
+fu_plugin_powerd_rescan (FuPlugin *plugin)
+{
+	FuContext *ctx = fu_plugin_get_context (plugin);
+	FuPluginData *data = fu_plugin_get_data (plugin);
+	
+      
+	state_val = g_dbus_proxy_get_cached_property (data->proxy, "State");
+	
+	fu_context_set_battery_state (ctx, g_variant_get_uint32 (state_val));
+
+	/* get percentage */
+	percentage_val = g_dbus_proxy_get_cached_property (data->proxy, "Percentage");
+    
+	fu_context_set_battery_level (ctx, g_variant_get_double (percentage_val));
+}
+
+static void
+fu_plugin_upower_proxy_changed_cb (GDBusProxy *proxy,
+				   GVariant *changed_properties,
+				   GStrv invalidated_properties,
+				   FuPlugin *plugin)
+{
+	//fu_plugin_upower_rescan (plugin);
+}
+
+gboolean
+fu_plugin_startup (FuPlugin *plugin, GError **error)
+{
+	
+	g_autofree gchar *name_owner = NULL;
+	g_autofree gchar *battery_str = NULL;
+
+	minimum_battery = MINIMUM_BATTERY_PERCENTAGE_FALLBACK;
+	
+	
+        /* success */
+	return TRUE;
+}
+
+gboolean
+fu_plugin_update_prepare (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
+			  FuDevice *device,
+			  GError **error)
+{
+
+	return TRUE;
+}

--- a/plugins/powerd/meson.build
+++ b/plugins/powerd/meson.build
@@ -1,13 +1,13 @@
 if host_machine.system() == 'linux'
-cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"']
+  #cargs = ['-DG_LOG_DOMAIN="FuPluginPowerd"']
 
-install_data(['upower.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
+#install_data(['daemon.quirk'],
+  #install_dir: join_paths(datadir, 'fwupd', 'quirks.d'))
 
-shared_module('fu_plugin_upower',
+'''shared_module('fu_plugin_cros_powerd',
   fu_hash,
   sources : [
-    'fu-plugin-upower.c',
+    'fu-plugin-cros-powerd.c',
   ],
   include_directories : [
     root_incdir,
@@ -20,13 +20,10 @@ shared_module('fu_plugin_upower',
     fwupd,
     fwupdplugin,
   ],
-  c_args : cargs,
-  dependencies : [
+  '''c_args : cargs,'''
+ ''' dependencies : [
     plugin_deps,
   ],
-)
+)'''
 
-install_data(['upower.conf'],
-  install_dir:  join_paths(sysconfdir, 'fwupd')
-)
 endif


### PR DESCRIPTION
Type of pull request:
- [ ] Code fix
- [ ] Documentation

This commit empties most of the fu-plugin-upower.c file and renames to fu-plugin-cros-powerd.c. It mostly does nothing, so it is a good starting place. It also changes the meson.build file and README.md documentation as specified in the commit message.
