### PR TITLE
inhibit system suspend during update

### DIFF
--- a/plugins/powerd/fu-plugin-powerd.c
+++ b/plugins/powerd/fu-plugin-powerd.c
@@ -9,6 +9,10 @@
 
 #include <fwupdplugin.h>
 
+#include <stdio.h>
+
+#include <unistd.h>
+
 void
 fu_plugin_init (FuPlugin *plugin)
 {
@@ -19,6 +23,19 @@ gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
         return TRUE;
+<<<<<<< HEAD
+=======
+}
+
+static void
+fu_plugin_inhibit_suspend ()
+{
+        g_autofree gchar *lockfilename = fu_common_get_path (FU_PATH_KIND_LOCKFILE);
+        FILE *inhibit_suspend_file;
+        inhibit_suspend_file = fopen (lockfilename, "w");
+        fprintf (inhibit_suspend_file, "%d", getpid());
+        fclose (inhibit_suspend_file);
+>>>>>>> 608f1be3 (CHROMIUM: inhibit system suspend during update)
 }
 
 gboolean
@@ -27,5 +44,21 @@ fu_plugin_update_prepare (FuPlugin *plugin,
                           FuDevice *device,
                           GError **error)
 {
+<<<<<<< HEAD
         return TRUE;
+=======
+        fu_plugin_inhibit_suspend ();
+
+        return TRUE;
+}
+
+gboolean
+fu_plugin_update_cleanup (FuPlugin *plugin,
+                          FwupdInstallFlags flags,
+                          FuDevice *dev,
+                          GError **error)
+{
+        g_autofree gchar *lockfilename = fu_common_get_path (FU_PATH_KIND_LOCKFILE);
+        return (remove (lockfilename) == 0);
+>>>>>>> 608f1be3 (CHROMIUM: inhibit system suspend during update)
 }


### PR DESCRIPTION
Create and destroy /run/lock/power_override/fwupd.lock.
This file will hold the contents of getpid (), which will
stop the device from being suspended while the file exists.
The file will be created and written just before the
update is put into motion and be destroyed once the update
finishes.

BUG=b:193239916
TEST=while running
fwupdtool install /usr/share/fwupd/remotes.d/vendor/firmware/c15a0df7386812781d1f376fe54729e64f69b2a8a6c4b580914d4f6740e4fcc3-HP-USBC_DOCK_G5-V1.0.13.0.cab --verbose --allow-reinstall
in one tmux window, running powerd_dbus_suspend in another.
closing laptop lid during install.
ensuring file is destroyed via
cat /run/lock/power_override/fwupd.lock